### PR TITLE
Fix homepage on Vercel

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -778,7 +778,10 @@ def home():
         # Generate daily briefing text
         briefing_text = generate_daily_briefing(articles, current_date)
         
-        return render_template('index_homepage.html',
+        # Use the simplified index template since index_homepage.html was
+        # removed in a previous cleanup commit. This restores the homepage on
+        # Vercel deployments.
+        return render_template('index.html',
                              articles=articles,
                              stats=stats,
                              today_episode=today_episode,


### PR DESCRIPTION
## Summary
- fix path to homepage template

## Testing
- `pytest -q` *(fails: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_68658f641a6083279a867d1105470062