### PR TITLE
Fix vercel runtime string

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,17 +2,17 @@
   "version": 2,
   "functions": {
     "api/index.py": {
-      "runtime": "python3.9",
+      "runtime": "vercel-python@4.7.4",
       "maxDuration": 60,
       "memory": 1024
     },
     "api/scrape.py": {
-      "runtime": "python3.9",
+      "runtime": "vercel-python@4.7.4",
       "maxDuration": 300,
       "memory": 512
     },
     "api/analyze.py": {
-      "runtime": "python3.9",
+      "runtime": "vercel-python@4.7.4",
       "maxDuration": 60,
       "memory": 512
     }


### PR DESCRIPTION
## Summary
- update runtime version for Python functions in `vercel.json`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: botocore.exceptions.NoCredentialsError)*

------
https://chatgpt.com/codex/tasks/task_e_687928e00cac8327aec46628acf8d7d3